### PR TITLE
Only digest `class`, `queue`, `args`, and `at` keys for the payload.

### DIFF
--- a/lib/sidekiq-middleware/core_ext.rb
+++ b/lib/sidekiq-middleware/core_ext.rb
@@ -1,0 +1,11 @@
+class Hash
+  def slice(*items)
+    items = items.to_a.flatten
+
+    {}.tap do |hash|
+      items.each do |item|
+        hash[item] = self[item] if self[item]
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,9 @@ require 'minitest/unit'
 require 'minitest/pride'
 require 'minitest/autorun'
 
+require 'celluloid'
+Celluloid.logger = nil
+
 require 'sidekiq'
 require 'sidekiq/util'
 require 'sidekiq-middleware'

--- a/test/test_core_ext.rb
+++ b/test/test_core_ext.rb
@@ -1,0 +1,28 @@
+require 'helper'
+require 'sidekiq-middleware/core_ext'
+
+class TestCoreExt < MiniTest::Unit::TestCase
+  describe 'for an empty array' do
+    it 'should be an ampty hash' do
+      assert_equal({}, {:foo => "bar"}.slice([]))
+    end
+  end
+
+  describe 'for items not in the hash' do
+    it 'should be an empty hash' do
+      assert_equal({}, {:foo => "bar", :foobar => "baz"}.slice(:baz, :foobaz))
+    end
+  end
+
+  describe 'for items in the hash' do
+    it 'should be the attributes' do
+      assert_equal({:foo => "bar"}, {:foo => "bar", :foobar => "baz"}.slice(:foo))
+    end
+  end
+
+  describe 'when all items are in the hash' do
+    it 'should be the hash' do
+      assert_equal({:foo => "bar", :foobar => "baz"}, {:foo => "bar", :foobar => "baz"}.slice(:foo, :foobar))
+    end
+  end
+end


### PR DESCRIPTION
This commit refactors and simplifies the middleware server and client as well as only enforcing the uniqueness of the payload across the keys for class, queue, args, and at. This means that other middleware can set custom information and not have the uniqueness invalidated by the message metadata.

It also adds the Hash#slice method for convenience.
