### PR TITLE
Slice if the hash contains the key, and only if not defined.

### DIFF
--- a/lib/sidekiq-middleware/core_ext.rb
+++ b/lib/sidekiq-middleware/core_ext.rb
@@ -4,8 +4,8 @@ class Hash
 
     {}.tap do |hash|
       items.each do |item|
-        hash[item] = self[item] if self[item]
+        hash[item] = self[item] if self.key?(item)
       end
     end
-  end
+  end unless new.respond_to?(:slice)
 end

--- a/test/test_core_ext.rb
+++ b/test/test_core_ext.rb
@@ -20,6 +20,12 @@ class TestCoreExt < MiniTest::Unit::TestCase
     end
   end
 
+  describe 'for keys in the hash' do
+    it 'should be the attributes' do
+      assert_equal({:foo => nil}, {:foo => nil, :foobar => "baz"}.slice(:foo))
+    end
+  end
+
   describe 'when all items are in the hash' do
     it 'should be the hash' do
       assert_equal({:foo => "bar", :foobar => "baz"}, {:foo => "bar", :foobar => "baz"}.slice(:foo, :foobar))


### PR DESCRIPTION
Forgot to make sure to only define this when not already defined. We also want keys that hold falsy values.
