### PR TITLE
Added ability to set custom lock key

### DIFF
--- a/lib/sidekiq-middleware.rb
+++ b/lib/sidekiq-middleware.rb
@@ -1,6 +1,7 @@
 require "digest"
 require "sidekiq-middleware/version"
 require "sidekiq-middleware/core_ext"
+require "sidekiq-middleware/unique_key"
 require "sidekiq-middleware/server/unique_jobs"
 require "sidekiq-middleware/client/unique_jobs"
 require "sidekiq-middleware/middleware"

--- a/lib/sidekiq-middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-middleware/client/unique_jobs.rb
@@ -18,7 +18,7 @@ module Sidekiq
               payload.delete('at')
             end
 
-            payload_hash = "locks:unique:#{Digest::MD5.hexdigest(Sidekiq.dump_json(payload))}"
+            payload_hash = Sidekiq::Middleware::UniqueKey.generate(worker_class, payload)
 
             Sidekiq.redis do |conn|
               conn.watch(payload_hash)

--- a/lib/sidekiq-middleware/server/unique_jobs.rb
+++ b/lib/sidekiq-middleware/server/unique_jobs.rb
@@ -27,12 +27,12 @@ module Sidekiq
           enabled, payload = worker_instance.class.get_sidekiq_options['unique'],
             item.clone.slice(*%w(class queue args at))
 
-          # Enabled unique scheduled 
+          # Enabled unique scheduled
           if enabled == :all && payload.has_key?('at')
             payload.delete('at')
           end
 
-          "locks:unique:#{Digest::MD5.hexdigest(Sidekiq.dump_json(payload))}"
+          Sidekiq::Middleware::UniqueKey.generate(worker_instance.class, payload)
         end
 
         def clear(worker_instance, item, queue)

--- a/lib/sidekiq-middleware/unique_key.rb
+++ b/lib/sidekiq-middleware/unique_key.rb
@@ -1,0 +1,14 @@
+module Sidekiq
+  module Middleware
+    module UniqueKey
+      def self.generate(worker_class, payload)
+        if worker_class.respond_to?(:lock)
+          worker_class.lock(*payload['args'])
+        else
+          json = Sidekiq.dump_json(payload)
+          "locks:unique:#{Digest::MD5.hexdigest(json)}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Like in [defunkt/resque-lock](https://github.com/defunkt/resque-lock):

``` ruby
class UniqueJob
  include Sidekiq::Worker

  sidekiq_options :queue => :unique_job, :unique => true

  def self.lock(id)
    'sidekiq:lock:unique_job'
  end

  def perform(id)
    # ...
  end
end
```
