### PR TITLE
Issue with client & server in the same application...

### DIFF
--- a/lib/sidekiq-middleware/middleware.rb
+++ b/lib/sidekiq-middleware/middleware.rb
@@ -2,9 +2,6 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sidekiq::Middleware::Server::UniqueJobs
   end
-  config.client_middleware do |chain|
-    chain.add Sidekiq::Middleware::Client::UniqueJobs
-  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
When running both client and server in the same app e.g.

``` ruby
        ::Sidekiq.configure_server do |config|
          config.options[:concurrency] = configuration[:concurrency] || 1
          config.options[:namespace] = 'sidekiq_job'
          config.poll_interval = 1
          config.redis = $redis_write
        end

        ::Sidekiq.configure_client do |config|
          config.options[:concurrency] = configuration[:concurrency] || 1
          config.options[:namespace] = 'sidekiq_job'
          config.redis = $redis_write
        end
```

The middleware is applied incorrectly, in my instance, when the server starts to process a job, the unique client middleware is called, thus failing on the first line `get_sidekiq_options`. 

Removing the nested chain of middleware (see code) on the server declaration fixes my issue.
