### PR TITLE
Update sidekiq dependency in gemspec

### DIFF
--- a/sidekiq-middleware.gemspec
+++ b/sidekiq-middleware.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::Middleware::VERSION
 
-  gem.add_dependency                  'sidekiq',  '~> 2.12.4'
+  gem.add_dependency                  'sidekiq',  '>= 2.12.4'
   gem.add_development_dependency      'rake'
   gem.add_development_dependency      'bundler',  '~> 1.0'
   gem.add_development_dependency      'minitest', '~> 3'


### PR DESCRIPTION
Update sidekiq dependency in gemspec to accomodate versions 2.13.1 & greater. Present version of sidekiq is [2.13.1](https://github.com/mperham/sidekiq/tree/v2.13.1), with head at [2.14.0](https://github.com/mperham/sidekiq/tree/2b5feb981df9150f26b8aac2451374816f7d0fbf).
