### PR TITLE
Implement option to not release lock after the job failed.

### DIFF
--- a/lib/sidekiq-middleware/helpers.rb
+++ b/lib/sidekiq-middleware/helpers.rb
@@ -29,6 +29,10 @@ module Sidekiq
         enabled
       end
 
+      def unlock_after_failure?(klass)
+        !klass.get_sidekiq_options['lock_after_failure']
+      end
+
       def unique_manual?(klass)
         klass.get_sidekiq_options['manual']
       end


### PR DESCRIPTION
By default jobs get unlocked when they failed, allowing the same job
to be queued again.

This commit introduces the `lock_after_failure` option which you can use
to keep the lock alive after failures. Just set it in your
sidekiq_options, e.g.:

``` ruby
class HardWorker
  include Sidekiq::Worker

  sidekiq_options unique: true, lock_after_failure: true
end
```

When `lock_after_failure" is not set, or set to false the job will be
unlocked after a failure, like before.

Note that I didn't add tests for now, because I wanted to start the discussion and honestly just hacked around a bit :) If you see this as useful contribution I'll add tests.

Thanks for making this gem and have a good day.
