### PR TITLE
Fixes method name typo `unique_expiration`

### DIFF
--- a/lib/sidekiq-middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-middleware/client/unique_jobs.rb
@@ -7,7 +7,7 @@ module Sidekiq
           enabled = Sidekiq::Middleware::Helpers.unique_enabled?(worker_class, item)
 
           if enabled
-            expiration = Sidekiq::Middleware::Helpers.unique_exiration(worker_class)
+            expiration = Sidekiq::Middleware::Helpers.unique_expiration(worker_class)
             job_id = item['jid']
 
             # Scheduled

--- a/lib/sidekiq-middleware/helpers.rb
+++ b/lib/sidekiq-middleware/helpers.rb
@@ -17,7 +17,7 @@ module Sidekiq
         end
       end
 
-      def unique_exiration(klass)
+      def unique_expiration(klass)
         klass.get_sidekiq_options['expiration'] || UNIQUE_EXPIRATION
       end
 


### PR DESCRIPTION
Hey there,

Thanks for such a great gem! I fixed a small typo on a method name I noticed while reading the code.
