### PR TITLE
update to work with rails ActiveJob::Wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 gem 'sidekiq', ENV['SIDEKIQ_VERSION'] if ENV['SIDEKIQ_VERSION']
 
 group :test do
+  gem 'minitest'
   gem 'simplecov', require: false
   gem 'coveralls', require: false
 end

--- a/sidekiq-middleware.gemspec
+++ b/sidekiq-middleware.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      'bundler',  '~> 1.0'
   gem.add_development_dependency      'minitest', '~> 3'
   gem.add_development_dependency      'timecop'
+  gem.add_development_dependency      'celluloid'
 end


### PR DESCRIPTION
rails 4 and 5 has an ActiveJob::Wrapper class that wraps the job classes. This fixes the unique_digest method to account for that.
